### PR TITLE
:fix _attr_current_option error on select entity + logs pour mqtt

### DIFF
--- a/custom_components/ecoflow_cloud/select.py
+++ b/custom_components/ecoflow_cloud/select.py
@@ -43,6 +43,8 @@ class DictSelectEntity(BaseSelectEntity):
             val = self.__options_dict[option]
             self.send_set_message(val, self.command_dict(val))
 
+    def current_option(self) -> str | None:
+        return super().current_option()
 
 class TimeoutDictSelectEntity(DictSelectEntity):
     _attr_icon = "mdi:timer-outline"


### PR DESCRIPTION
Fix sur les entités suivantes :
TimeoutDictSelectEntity
PowerDictSelectEntity

Avec des erreurs sur :
object xxx has no attribute '__attr_current_option'